### PR TITLE
Fix subnet mask

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure("2") do |config|
   # assigned by DHCP
   #config.vm.network "public_network"
   # assigned by static
-  config.vm.network "public_network", ip:"192.168.10.233/16"
+  config.vm.network "public_network", ip:"192.168.10.233", netmask:"255.255.0.0"
 
   config.vm.synced_folder "./conf", "/tftpboot", mount_options: ['dmode=777','fmode=755']
 


### PR DESCRIPTION
Was creating this error message:

```
/etc/netplan/50-vagrant.yaml:8:7: Error in network definition: malformed address '192.168.10.233/16/24', must be X.X.X.X/NN or X:X:X:X:X:X:X:X/NN
      - 192.168.10.233/16/24
```

It looks like Vagrant now assumes /24 unless you specify a netmask instead.